### PR TITLE
修复HTTPS下无法正常显示的问题

### DIFF
--- a/tz.php
+++ b/tz.php
@@ -1031,7 +1031,7 @@ input.btn{font-weight: bold; height: 20px; line-height: 20px; padding: 0 6px; co
 -->
 </style>
 
-<script language="JavaScript" type="text/javascript" src="http://lib.sinaapp.com/js/jquery/1.7/jquery.min.js"></script>
+<script language="JavaScript" type="text/javascript" src="https://lib.sinaapp.com/js/jquery/1.7/jquery.min.js"></script>
 
 <script type="text/javascript"> 
 


### PR DESCRIPTION
在HTTPS页面引用HTTP内容会自动被浏览器阻断，修改jquery地址到https以避免此问题